### PR TITLE
make Grass correctly snap to terrain when scaled

### DIFF
--- a/addons/zylann.hterrain/shaders/detail.shader
+++ b/addons/zylann.hterrain/shaders/detail.shader
@@ -49,7 +49,11 @@ void vertex() {
 	
 	if (density > hash) {
 		// Snap model to the terrain
-		float height = texture(u_terrain_heightmap, map_uv).r;
+		//float height = texture(u_terrain_heightmap, map_uv).r;
+		// BUT consider Map scale in Y direction:
+		float y_scale_factor = (u_terrain_inverse_transform * vec4(0,1,0,1)).y;
+		float height = texture(u_terrain_heightmap, map_uv).r / y_scale_factor;
+		
 		VERTEX.y += height;
 		
 		VERTEX += get_ambient_wind_displacement(UV, hash);


### PR DESCRIPTION
makes grass snap to terrain correctly in the shader even when "map scale"  Y value is different from 1

pretty hacky and just cobbled together from what I found in the shader but it works (edit: I think)

my first ever pull request too so let me know if I've done anything dumb