### PR TITLE
Fixed for Terrain directory always empty - Data not saving #81

### DIFF
--- a/addons/zylann.hterrain/hterrain_resource_loader.gd
+++ b/addons/zylann.hterrain/hterrain_resource_loader.gd
@@ -1,6 +1,6 @@
 tool
-class_name HTerrainDataLoader
 extends ResourceFormatLoader
+class_name HTerrainDataLoader
 
 
 const HTerrainData = preload("hterrain_data.gd")

--- a/addons/zylann.hterrain/hterrain_resource_saver.gd
+++ b/addons/zylann.hterrain/hterrain_resource_saver.gd
@@ -1,6 +1,6 @@
 tool
-class_name HTerrainDataSaver
 extends ResourceFormatSaver
+class_name HTerrainDataSaver
 
 
 const HTerrainData = preload("hterrain_data.gd")


### PR DESCRIPTION
(https://github.com/Zylann/godot_heightmap_plugin/issues/81)

this caused by syntax changed and previous code will cause an error "'extends' must be used before anything else".
this error cause the save to folder always failed so nothing is saved.