### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~
+
 # Build
 *.obj
 *.exp
@@ -18,12 +36,12 @@
 *.includes
 
 # Godot
-.import/
 logs/
 default_env.tres
 
 # VSCode
 *.vs/
+.vscode/
 
 # Windows
 *.bat


### PR DESCRIPTION
The gitignore was missing a few things and was a bit outdated, so I updated it.

The way it's formatted is that the top of the file is based on Godot's official gitignore, and the bottom part is everything that was previously in the gitignore.

I also added `.vscode/` since the comment says `# VSCode` but the ignored folder is for Visual Studio, and I assume that you intended to have VS Code's folder ignored.