### PR TITLE
Add "island mode" to the terrain generator.

### DIFF
--- a/addons/zylann.hterrain/tools/generator/generator_dialog.gd
+++ b/addons/zylann.hterrain/tools/generator/generator_dialog.gd
@@ -113,6 +113,15 @@ func _ready():
 		"shadows": {
 			"type": TYPE_BOOL,
 			"default_value": true
+		},
+		"island_mode": {
+			"type": TYPE_BOOL,
+			"default_value": false
+		},
+		"island_exponent": {
+			"type": TYPE_REAL,
+			"range": { "min": 0.1, "max": 1 },
+			"default_value": 1.0
 		}
 	})
 
@@ -267,7 +276,9 @@ func _update_generator(preview: bool):
 			"u_base_height": _inspector.get_value("base_height") / preview_scale,
 			"u_height_range": _inspector.get_value("height_range") / preview_scale,
 			"u_roughness": _inspector.get_value("roughness"),
-			"u_curve": _inspector.get_value("curve")
+			"u_curve": _inspector.get_value("curve"),
+			"u_island_factor": 1.0 if _inspector.get_value("island_mode") else 0.0,
+			"u_island_exponent": _inspector.get_value("island_exponent"),
 		}
 		_generator.add_pass(p)
 

--- a/addons/zylann.hterrain/tools/generator/shaders/perlin_noise.shader
+++ b/addons/zylann.hterrain/tools/generator/shaders/perlin_noise.shader
@@ -10,6 +10,8 @@ uniform float u_roughness = 0.5;
 uniform float u_curve = 1.0;
 uniform vec2 u_uv_offset;
 uniform vec2 u_uv_scale = vec2(1.0, 1.0);
+uniform float u_island_factor = 0.0;
+uniform float u_island_exponent = 1.0;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Perlin noise source:
@@ -103,15 +105,19 @@ float get_fractal_noise(vec2 uv) {
 	return gs;
 }
 
-float get_height(vec2 uv) {
+float get_height(vec2 uv, float hf) {
 	float h = 0.5 + 0.5 * get_fractal_noise(uv);
 	h = pow(h, u_curve);
-	h = u_base_height + h * u_height_range;
+	h = u_base_height + h * u_height_range * hf;
 	return h;
 }
 
+const float PI = 3.14159265358979323846;
 void fragment() {
 	vec2 uv = SCREEN_UV;
+
+    float hf = 1.0 - u_island_factor * (1.0 -
+        pow(sin(uv.x * PI) * sin(uv.y * PI), u_island_exponent));
 
 	// Handle screen padding: transform UV back into generation space
 	uv = (uv + u_uv_offset) * u_uv_scale;
@@ -119,6 +125,6 @@ void fragment() {
 	// Offset and scale for the noise itself
 	uv = (uv + u_offset) * u_scale;
 
-	float h = get_height(uv);
+	float h = get_height(uv, hf);
 	COLOR = vec4(h, h, h, 1.0);
 }


### PR DESCRIPTION
This PR adds an "island mode" to the terrain generator that ensures that a complete island will be generated.

![image](https://user-images.githubusercontent.com/15330948/109454820-f645dc80-7a09-11eb-9238-2ea948de0e4a.png)

It does this by multiplying the calculated height by `sin(uv.x * PI) * sin(uv.y * PI)` raised to the "island exponent". This will ensure that the generated terrain will have its peak somewhere in the center and will have a height close to 0 near the edges.

For example here is the sinusoidal used when "island exponent" is 0.5 (i.e. square root):

https://www.desmos.com/calculator/2ykx6fzx1s

Tested against Godot 3.2.4 RC3.