### PR TITLE
Expose anisotropic filtering in packed textures

### DIFF
--- a/addons/zylann.hterrain/tools/packed_textures/packed_texture_importer.gd
+++ b/addons/zylann.hterrain/tools/packed_textures/packed_texture_importer.gd
@@ -63,6 +63,10 @@ func get_import_options(preset_index: int) -> Array:
 		{
 			"name": "flags/mipmaps",
 			"default_value": true
+		},
+		{
+			"name": "flags/anisotropic",
+			"default_value": false
 		}
 	]
 
@@ -115,6 +119,7 @@ func _import(p_source_path: String, p_save_path: String, options: Dictionary,
 			.with_value(result.value)
 
 	var image : Image = result.value
+
 	
 	result = StreamTextureImporter.import(
 		p_source_path, 
@@ -127,7 +132,8 @@ func _import(p_source_path: String, p_save_path: String, options: Dictionary,
 		options["compress/mode"],
 		options["flags/repeat"],
 		options["flags/filter"],
-		options["flags/mipmaps"])
+		options["flags/mipmaps"],
+		options["flags/anisotropic"])
 	
 	if not result.success:
 		return Result.new(false, 

--- a/addons/zylann.hterrain/tools/packed_textures/stream_texture_importer.gd
+++ b/addons/zylann.hterrain/tools/packed_textures/stream_texture_importer.gd
@@ -43,14 +43,15 @@ static func import(
 	p_compress_mode: int,
 	p_repeat: int,
 	p_filter: bool,
-	p_mipmaps: bool) -> Result:
+	p_mipmaps: bool,
+	p_anisotropic: bool) -> Result:
 
 	var compress_mode := p_compress_mode
 	var lossy := 0.7
 	var repeat := p_repeat
 	var filter := p_filter
 	var mipmaps := p_mipmaps
-	var anisotropic := false
+	var anisotropic := p_anisotropic
 	var srgb := 1 if p_contains_albedo else 2
 	var fix_alpha_border := false
 	var premult_alpha := false


### PR DESCRIPTION
Sometimes textures looks blurry from oblique angles. This PR adds an option to imported HTerrainPackedTexture resources to enable an anisotropic filtering.
Without:
![image](https://user-images.githubusercontent.com/1286923/127349230-6c248b2f-502b-47ce-a13d-4f218a2362c5.png)
And with anisotropic turned on:
![image](https://user-images.githubusercontent.com/1286923/127349305-cf23c785-cb36-4afb-b1fa-5ebefab4665e.png)

As variable _WRITE_IMPORT_FILES  ```addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd``` is disabled, this PR only adds this option in the importer section of Godot.