### PR TITLE
Fix function rename to get_camera_3d() in hterrain.gd

### DIFF
--- a/addons/zylann.hterrain/hterrain.gd
+++ b/addons/zylann.hterrain/hterrain.gd
@@ -1161,7 +1161,7 @@ func _update_viewer_position(camera: Camera3D):
 	if camera == null:
 		var viewport := get_viewport()
 		if viewport != null:
-			camera = viewport.get_camera()
+			camera = viewport.get_camera_3d()
 	
 	if camera == null:
 		return


### PR DESCRIPTION
The function of `get_viewport().get_camera()` got renamed to `get_viewport().get_camera_3d()`