### PR TITLE
Alternate height encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For a more detailed list of past and incoming changes, see the commit history.
 - Added `cast_shadow` setting to `HTerrain`
 - Added `cast_shadow` setting to `HTerrainDetailLayer`
 - Added slope limit slider to detail density painting
+- Added 24-bit support for importing raw files
+- Added 24-bit support for exporting raw files
 - Exposed `roughness` in detail layer shader (but reflections may be off due to the normals hack)
 - Allow decimal values in `min_height` and `max_height` when importing a heightmap
 - Fixed terrain not functional when using a 32-bit version of Godot (The GDNative library is only maintained for 64-bit)

--- a/addons/zylann.hterrain/doc/docs/index.md
+++ b/addons/zylann.hterrain/doc/docs/index.md
@@ -689,7 +689,7 @@ This window allows you to import several kinds of data, such as heightmap but al
 There are a few things to check before you can successfully import a terrain though:
 
 - The resolution should be power of two + 1, and square. If it isn't, the plugin will attempt to crop it, which might be OK or not if you can deal with map borders that this will produce.
-- If you import a RAW heightmap, it has to be encoded using 16-bit unsigned integer format.
+- If you import a RAW heightmap, it has to be encoded using either 16-bit or 24-bit unsigned integer format. Upon selecting a file via the file chooser dialog, the importer will attempt to deduce the bit depth.
 - If you import a PNG heightmap, Godot can only load it as 8-bit depth, so it is not recommended for high-range terrains because it doesn't have enough height precision.
 
 This feature also can't be undone when executed, as all terrain data will be overwritten with the new one. If anything isn't correct, the tool will warn you before to prevent data loss.

--- a/addons/zylann.hterrain/hterrain_data.gd
+++ b/addons/zylann.hterrain/hterrain_data.gd
@@ -1700,23 +1700,28 @@ static func get_map_shader_param_name(map_type: int, index: int) -> String:
 #	return null
 
 
-const _V2_UNIT_STEPS = 1024.0
+const _V2_UNIT_STEPS = 100.0
 const _V2_MIN = -8192.0
-const _V2_MAX = 8191.0
-const _V2_DF = 255.0 / _V2_UNIT_STEPS
 
 
 static func decode_height_from_rgb8_unorm(c: Color) -> float:
-	return (c.r * 0.25 + c.g * 64.0 + c.b * 16384.0) * (4.0 * _V2_DF) + _V2_MIN
+	var res:int = int(c.b * 255.0)
+	res <<= 8
+	res |= int(c.g * 255.0)
+	res <<= 8
+	res |= int(c.r * 255.0)
+
+	return (float(res) / _V2_UNIT_STEPS) + _V2_MIN
 
 
 static func encode_height_to_rgb8_unorm(h: float) -> Color:
 	h -= _V2_MIN
-	var i := int(h * _V2_UNIT_STEPS)
-	var r := i % 256
-	var g := (i / 256) % 256
-	var b := i / 65536
-	return Color(r, g, b, 255.0) / 255.0
+	var hi:int = int(h * _V2_UNIT_STEPS)
+	var r := float(hi&0xff) / 255.0
+	var g := float((hi>>8)&0xff) / 255.0
+	var b := float((hi>>16)&0xff) / 255.0
+
+	return Color(r, g, b, 1.0)
 
 
 static func convert_heightmap_to_float(src: Image, logger: HT_Logger.HT_LoggerBase) -> Image:

--- a/addons/zylann.hterrain/hterrain_data.gd
+++ b/addons/zylann.hterrain/hterrain_data.gd
@@ -1700,7 +1700,7 @@ static func get_map_shader_param_name(map_type: int, index: int) -> String:
 #	return null
 
 
-const _V2_UNIT_STEPS = 100.0
+const _V2_UNIT_STEPS = 1024.0
 const _V2_MIN = -8192.0
 
 
@@ -1722,6 +1722,20 @@ static func encode_height_to_rgb8_unorm(h: float) -> Color:
 	var b := float((hi>>16)&0xff) / 255.0
 
 	return Color(r, g, b, 1.0)
+
+const _V2_MAX = 8191.0
+const _V2_DF = 255.0 / _V2_UNIT_STEPS
+
+static func prev_decode_height_from_rgb8_unorm(c: Color) -> float:
+	return (c.r * 0.25 + c.g * 64.0 + c.b * 16384.0) * (4.0 * _V2_DF) + _V2_MIN
+
+static func prev_encode_height_to_rgb8_unorm(h: float) -> Color:
+	h -= _V2_MIN
+	var i := int(h * _V2_UNIT_STEPS)
+	var r := i % 256
+	var g := (i / 256) % 256
+	var b := i / 65536
+	return Color(r, g, b, 255.0) / 255.0
 
 
 static func convert_heightmap_to_float(src: Image, logger: HT_Logger.HT_LoggerBase) -> Image:

--- a/addons/zylann.hterrain/shaders/include/heightmap_rgb8_encoding.gdshaderinc
+++ b/addons/zylann.hterrain/shaders/include/heightmap_rgb8_encoding.gdshaderinc
@@ -1,5 +1,5 @@
 
-const float V2_UNIT_STEPS = 100.0;
+const float V2_UNIT_STEPS = 1024.0;
 const float V2_MIN = -8192.0;
 
 float decode_height_from_rgb8_unorm_2(vec3 c) {

--- a/addons/zylann.hterrain/shaders/include/heightmap_rgb8_encoding.gdshaderinc
+++ b/addons/zylann.hterrain/shaders/include/heightmap_rgb8_encoding.gdshaderinc
@@ -1,22 +1,25 @@
 
-const float V2_UNIT_STEPS = 1024.0;
+const float V2_UNIT_STEPS = 100.0;
 const float V2_MIN = -8192.0;
-const float V2_MAX = 8191.0;
-const float V2_DF = 255.0 / V2_UNIT_STEPS;
 
 float decode_height_from_rgb8_unorm_2(vec3 c) {
-	return (c.r * 0.25 + c.g * 64.0 + c.b * 16384.0) * (4.0 * V2_DF) + V2_MIN;
+	int res = int(c.b * 255.0);
+	res <<= 8;
+	res |= int(c.g * 255.0);
+	res <<= 8;
+	res |= int(c.r * 255.0);
+
+	return (float(res) / V2_UNIT_STEPS) + V2_MIN;
 }
 
 vec3 encode_height_to_rgb8_unorm_2(float h) {
 	// TODO Check if this has float precision issues
-	// TODO Modulo operator might be a performance/compatibility issue
 	h -= V2_MIN;
-	int i = int(h * V2_UNIT_STEPS);
-	int r = i % 256;
-	int g = (i / 256) % 256;
-	int b = i / 65536;
-	return vec3(float(r), float(g), float(b)) / 255.0;
+	int hi = int(h * V2_UNIT_STEPS);
+	float r = float(hi&0xff) / 255.0;
+	float g = float((hi>>8)&0xff) / 255.0;
+	float b = float((hi>>16)&0xff) / 255.0;
+	return vec3(r, g, b);
 }
 
 float decode_height_from_rgb8_unorm(vec3 c) {

--- a/addons/zylann.hterrain/tools/importer/importer_dialog.gd
+++ b/addons/zylann.hterrain/tools/importer/importer_dialog.gd
@@ -16,8 +16,11 @@ signal permanent_change_performed(message)
 @onready var _warnings_label : Label = \
 	$VBoxContainer/ColorRect/ScrollContainer/VBoxContainer/Warnings
 
-const RAW_LITTLE_ENDIAN = 0
-const RAW_BIG_ENDIAN = 1
+
+enum {
+	RAW_LITTLE_ENDIAN,
+	RAW_BIG_ENDIAN
+}
 
 var _terrain : HTerrain = null
 var _logger = HT_Logger.get_for(self)
@@ -37,7 +40,13 @@ func _ready():
 		"raw_endianess": {
 			"type": TYPE_INT,
 			"usage": "enum",
-			"enum_items": ["Little Endian", "Big Endian"],
+			"enum_items": [[RAW_LITTLE_ENDIAN, "Little Endian"], [RAW_BIG_ENDIAN, "Big Endian"]],
+			"enabled": false
+		},
+		"bit_depth": {
+			"type": TYPE_INT,
+			"usage": "enum",
+			"enum_items": [[HTerrainData.BIT_DEPTH_UNDEFINED, "Undefined"], [HTerrainData.BIT_DEPTH_16, "16-bit"], [HTerrainData.BIT_DEPTH_24, "24-bit"]],
 			"enabled": false
 		},
 		"min_height": {
@@ -61,7 +70,8 @@ func _ready():
 			"exts": ["png"]
 		}
 	})
-	
+	_inspector.set_item_disabled("bit_depth", HTerrainData.BIT_DEPTH_UNDEFINED, true)
+
 	# Testing
 #	_errors_label.text = "- Hello World!"
 #	_warnings_label.text = "- Yolo Jesus!"
@@ -137,7 +147,8 @@ func _on_ImportButton_pressed():
 			"path": heightmap_path,
 			"min_height": _inspector.get_value("min_height"),
 			"max_height": _inspector.get_value("max_height"),
-			"big_endian": endianess == RAW_BIG_ENDIAN
+			"big_endian": endianess == RAW_BIG_ENDIAN,
+			"bit_depth": _inspector.get_value("bit_depth"),
 		}
 
 	var colormap_path = _inspector.get_value("colormap")
@@ -168,6 +179,34 @@ func _on_Inspector_property_changed(key: String, value):
 	if key == "heightmap":
 		var is_raw = value.get_extension().to_lower() == "raw"
 		_inspector.set_property_enabled("raw_endianess", is_raw)
+		_inspector.set_property_enabled("bit_depth", is_raw)
+		var reset_bit_depth:bool = true
+		if is_raw:
+			var bit_depth:int = _estimate_bit_depth_for_raw_file(value)
+			if bit_depth >= HTerrainData.BIT_DEPTH_UNDEFINED:
+				_inspector.set_value("bit_depth", bit_depth)
+				reset_bit_depth = false
+		if reset_bit_depth:
+			_inspector.set_value("bit_depth", HTerrainData.BIT_DEPTH_UNDEFINED)
+
+
+# _estimate_bit_depth_for_raw_file returns the file's identified bit depth, or 0.
+static func _estimate_bit_depth_for_raw_file(path: String) -> int:
+	var ext := path.get_extension().to_lower()
+	if ext == "raw":
+		var f := FileAccess.open(path, FileAccess.READ)
+		if f == null:
+			return HTerrainData.BIT_DEPTH_UNDEFINED
+
+		var file_len := f.get_length()
+		f = null # close file
+
+		for bit_depth in [HTerrainData.BIT_DEPTH_16, HTerrainData.BIT_DEPTH_24]:
+			var file_res := HT_Util.integer_square_root(file_len / (bit_depth/8))
+			if file_res > 0:
+				return bit_depth
+
+	return HTerrainData.BIT_DEPTH_UNDEFINED
 
 
 func _validate_form() -> HT_ErrorCheckReport:
@@ -176,6 +215,7 @@ func _validate_form() -> HT_ErrorCheckReport:
 	var heightmap_path : String = _inspector.get_value("heightmap")
 	var splatmap_path : String = _inspector.get_value("splatmap")
 	var colormap_path : String = _inspector.get_value("colormap")
+	var bit_depth = _inspector.get_value("bit_depth")
 
 	if colormap_path == "" and heightmap_path == "" and splatmap_path == "":
 		res.errors.append("No maps specified.")
@@ -195,7 +235,7 @@ func _validate_form() -> HT_ErrorCheckReport:
 			# so we avoid loading other maps everytime to do further checks
 			return res
 
-		var image_size_result = _load_image_size(heightmap_path, _logger)
+		var image_size_result = _load_image_size(heightmap_path, _logger, bit_depth)
 		if image_size_result.error_code != OK:
 			res.errors.append(str("Cannot open heightmap file: ", image_size_result.to_string()))
 			return res
@@ -211,18 +251,18 @@ func _validate_form() -> HT_ErrorCheckReport:
 		heightmap_size = adjusted_size
 
 	if splatmap_path != "":
-		_check_map_size(splatmap_path, "splatmap", heightmap_size, res, _logger)
+		_check_map_size(splatmap_path, "splatmap", heightmap_size, bit_depth, res, _logger)
 
 	if colormap_path != "":
-		_check_map_size(colormap_path, "colormap", heightmap_size, res, _logger)
+		_check_map_size(colormap_path, "colormap", heightmap_size, bit_depth, res, _logger)
 
 	return res
 
 
-static func _check_map_size(path: String, map_name: String, heightmap_size: int, 
+static func _check_map_size(path: String, map_name: String, heightmap_size: int, bit_depth: int, 
 	res: HT_ErrorCheckReport, logger):
 	
-	var size_result := _load_image_size(path, logger)
+	var size_result := _load_image_size(path, logger, bit_depth)
 	if size_result.error_code != OK:
 		res.errors.append(str("Cannot open splatmap file: ", size_result.to_string()))
 		return
@@ -251,7 +291,7 @@ class HT_ImageSizeResult:
 		return HT_Errors.get_message(error_code)
 
 
-static func _load_image_size(path: String, logger) -> HT_ImageSizeResult:
+static func _load_image_size(path: String, logger, bit_depth: int) -> HT_ImageSizeResult:
 	var ext := path.get_extension().to_lower()
 	var result := HT_ImageSizeResult.new()
 
@@ -269,6 +309,11 @@ static func _load_image_size(path: String, logger) -> HT_ImageSizeResult:
 		return result
 
 	elif ext == "raw":
+		if bit_depth != HTerrainData.BIT_DEPTH_16 && bit_depth != HTerrainData.BIT_DEPTH_24:
+			result.error_code = ERR_INVALID_DATA
+			result.error_message = "Invalid bit depth for .raw file import: {0}. Only 16-bit or 24-bit supported...".format([bit_depth])
+			return result
+
 		var f := FileAccess.open(path, FileAccess.READ)
 		if f == null:
 			var err := FileAccess.get_open_error()
@@ -276,14 +321,13 @@ static func _load_image_size(path: String, logger) -> HT_ImageSizeResult:
 			result.error_code = err
 			return result
 
-		# Assume the raw data is square in 16-bit format,
-		# so its size is function of file length
+		# Assume the raw data is square, so its size is function of file length
 		var flen := f.get_length()
 		f = null
-		var size_px = HT_Util.integer_square_root(flen / 2)
+		var size_px = HT_Util.integer_square_root(flen / (bit_depth/8))
 		if size_px == -1:
 			result.error_code = ERR_INVALID_DATA
-			result.error_message = "RAW image is not square"
+			result.error_message = "RAW image is not square or your bit depth choice is incorrect…"
 			return result
 		
 		logger.debug("Deduced RAW heightmap resolution: {0}*{1}, for a length of {2}" \

--- a/addons/zylann.hterrain/util/util.gd
+++ b/addons/zylann.hterrain/util/util.gd
@@ -77,6 +77,21 @@ static func file_get_24(f: FileAccess) -> int:
 	return res
 
 
+static func file_store_24(f: FileAccess, h: int) -> void:
+	var a : int = h & 0xff
+	var b : int = (h >> 8) & 0xff
+	var c : int = (h >> 16) & 0xff
+
+	if f.big_endian:
+		var tmp : int = a
+		a = c
+		c = tmp
+
+	f.store_8(a)
+	f.store_8(b)
+	f.store_8(c)
+
+
 static func integer_square_root(x: int) -> int:
 	assert(typeof(x) == TYPE_INT)
 	var r := int(roundf(sqrt(x)))

--- a/addons/zylann.hterrain/util/util.gd
+++ b/addons/zylann.hterrain/util/util.gd
@@ -57,6 +57,26 @@ static func create_wirecube_mesh(color = Color(1,1,1)) -> Mesh:
 	return mesh
 
 
+static func file_get_24(f: FileAccess) -> int:
+	var res : int
+	var a : int = f.get_8()
+	var b : int = f.get_8()
+	var c : int = f.get_8()
+
+	if f.big_endian:
+		var tmp : int = a
+		a = c
+		c = tmp
+
+	res = c
+	res <<= 8
+	res |= b
+	res <<= 8
+	res |= a
+
+	return res
+
+
 static func integer_square_root(x: int) -> int:
 	assert(typeof(x) == TYPE_INT)
 	var r := int(roundf(sqrt(x)))


### PR DESCRIPTION
Fixes https://github.com/Zylann/godot_heightmap_plugin/issues/368
* still WIP -> precision more or less the same
* new algorithm is simpler and faster and output seems more consistent
* breaks compatibility with existing heightmaps -> need upgrade func

**NOTE**: based on my PR https://github.com/Zylann/godot_heightmap_plugin/pull/369 to allow me to import heightmaps of sufficient quality. Will rebase once that PR has been merged  
Therefore, please only see newest commit: _Change heightmap encoding_

---

On import:
* min height: 0.0
* max height: 131.87

On Export, calculated:
* min height: 0.0
* max height: 131.78027

before, auto-calculated heights on export were:
* min height: 0.0004844
* max height: 131.78074


## Benchmarking

new encoding+decoding: max diff 0-0.000977 over 7229.061 msecs
previous encoding+decoding: max diff 0-0.`000975` over 7304.282 msecs
new encoding+decoding: max diff 0-0.000977 over 7148.446 msecs
previous encoding+decoding: max diff 0-0.`000976` over 7224.242 msecs
new encoding+decoding: max diff 0-0.000977 over 7099.373 msecs
previous encoding+decoding: max diff 0-0.000975 over 7174.645 msecs

**current progress result: Basically equal precision loss but faster and output seems consistent** (rounding in current logic seems to round differently sometimes)