### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Get submodules and their sub-submodules
           submodules: recursive
@@ -28,7 +28,7 @@ jobs:
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       # Because at the time the container comes with Python 2.7 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -56,8 +56,7 @@ jobs:
           scons platform=linux target=release
       
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: libhterrain_native.so
           path: addons/zylann.hterrain/native/bin/linux/libhterrain_native.so
-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Get submodules and their sub-submodules
           submodules: recursive
@@ -28,7 +28,7 @@ jobs:
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       # Because at the time the container comes with Python 2.7 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -56,8 +56,7 @@ jobs:
           scons platform=osx target=release
       
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: libhterrain_native.dylib
           path: addons/zylann.hterrain/native/bin/osx/libhterrain_native.dylib
-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Get submodules and their sub-submodules
           submodules: recursive
@@ -28,7 +28,7 @@ jobs:
       # Use python 3.x release (works cross platform; best to keep self contained in it's own step)
       # Because at the time the container comes with Python 2.7 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Semantic version range syntax or exact version of a Python version
           python-version: '3.x'
@@ -56,7 +56,7 @@ jobs:
           scons platform=windows target=release
       
       # Make build available
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: hterrain_native.dll
           path: addons/zylann.hterrain/native/bin/win64/hterrain_native.dll


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* update [`actions/setup-python`](https://github.com/actions/setup-python) to v4
* update [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to v3

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/Zylann/godot_heightmap_plugin/actions/runs/4506394476:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.