### PR TITLE
Change brush editor value nodes from Label to SpinBox

### DIFF
--- a/addons/zylann.hterrain/tools/brush/brush_editor.gd
+++ b/addons/zylann.hterrain/tools/brush/brush_editor.gd
@@ -13,12 +13,12 @@ const HT_BrushSettingsDialog = preload("./settings_dialog/brush_settings_dialog.
 
 
 @onready var _size_slider : Slider = $GridContainer/BrushSizeControl/Slider
-@onready var _size_value_label : Label = $GridContainer/BrushSizeControl/Label
+@onready var _size_spin_box : SpinBox = $GridContainer/BrushSizeControl/SpinBox
 #onready var _size_label = _params_container.get_node("BrushSizeLabel")
 
 @onready var _opacity_slider : Slider = $GridContainer/BrushOpacityControl/Slider
-@onready var _opacity_value_label : Label = $GridContainer/BrushOpacityControl/Label
 @onready var _opacity_control : Control = $GridContainer/BrushOpacityControl
+@onready var _opacity_spin_box : SpinBox = $GridContainer/BrushOpacityControl/SpinBox
 @onready var _opacity_label : Label = $GridContainer/BrushOpacityLabel
 
 @onready var _flatten_height_container : Control = $GridContainer/HB
@@ -58,7 +58,9 @@ func _set_visibility_of(node: Control, v: bool):
 
 func _ready():
 	_size_slider.value_changed.connect(_on_size_slider_value_changed)
+	_size_slider.share(_size_spin_box)
 	_opacity_slider.value_changed.connect(_on_opacity_slider_value_changed)
+	_opacity_slider.share(_opacity_spin_box)
 	_flatten_height_box.value_changed.connect(_on_flatten_height_box_value_changed)
 	_color_picker.color_changed.connect(_on_color_picker_color_changed)
 	_density_slider.value_changed.connect(_on_density_slider_changed)
@@ -190,13 +192,11 @@ func set_display_mode(mode: int):
 func _on_size_slider_value_changed(v: float):
 	if _terrain_painter != null:
 		_terrain_painter.set_brush_size(int(v))
-	_size_value_label.text = str(v)
 
 
 func _on_opacity_slider_value_changed(v: float):
 	if _terrain_painter != null:
 		_terrain_painter.set_opacity(_opacity_slider.ratio)
-	_opacity_value_label.text = str(v)
 
 
 func _on_flatten_height_box_value_changed(v: float):

--- a/addons/zylann.hterrain/tools/brush/brush_editor.tscn
+++ b/addons/zylann.hterrain/tools/brush/brush_editor.tscn
@@ -50,9 +50,11 @@ value = 2.0
 exp_edit = true
 rounded = true
 
-[node name="Label" type="Label" parent="GridContainer/BrushSizeControl"]
+[node name="SpinBox" type="SpinBox" parent="GridContainer/BrushSizeControl"]
 layout_mode = 2
-text = "999"
+min_value = 2.0
+max_value = 500.0
+value = 2.0
 
 [node name="BrushOpacityLabel" type="Label" parent="GridContainer"]
 layout_mode = 2
@@ -67,9 +69,9 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 
-[node name="Label" type="Label" parent="GridContainer/BrushOpacityControl"]
+[node name="SpinBox" type="SpinBox" parent="GridContainer/BrushOpacityControl"]
 layout_mode = 2
-text = "999"
+value = 1.0
 
 [node name="FlattenHeightLabel" type="Label" parent="GridContainer"]
 layout_mode = 2


### PR DESCRIPTION
This pull request changes the brush editor value label nodes from Label to SpinBox. This should improve ux as it is much easier to set a specific value. 

I don't like that there are 4 functions to sync all the values though, i.e. __on_size_slider_value_changed_, __on_size_spin_box_value_changed_. I can consolidate these if requested.

Image shown ui changes:
![heightbrush](https://github.com/Zylann/godot_heightmap_plugin/assets/10586460/57696c0f-70b9-460f-ad33-feb4f25bc00c)
