### PR TITLE
Fix 'loaded resource as image file' warnings

### DIFF
--- a/addons/zylann.hterrain/hterrain_data.gd
+++ b/addons/zylann.hterrain/hterrain_data.gd
@@ -1392,9 +1392,9 @@ func _load_map(dir: String, map_type: int, index: int, resource_loader_cache_mod
 			# But in the editor we want textures to be editable,
 			# so we have to automatically load the data also in RAM
 			if map.image == null:
-				map.image = Image.load_from_file(fpath)
+				map.image = Image.load_from_file(ProjectSettings.globalize_path(fpath))
 			else:
-				map.image.load(fpath)
+				map.image.load(ProjectSettings.globalize_path(fpath))
 		_ensure_map_format(map.image, map_type, index)
 	
 	if map_type == CHANNEL_HEIGHT:
@@ -1466,7 +1466,7 @@ func _import_heightmap(fpath: String, min_y: float, max_y: float, big_endian: bo
 		# Godot can only load 8-bit PNG,
 		# so we have to bring it back to float in the wanted range
 
-		var src_image := Image.load_from_file(fpath)
+		var src_image := Image.load_from_file(ProjectSettings.globalize_path(fpath))
 		# TODO No way to access the error code?
 		if src_image == null:
 			return false
@@ -1509,7 +1509,7 @@ func _import_heightmap(fpath: String, min_y: float, max_y: float, big_endian: bo
 				_logger.error(str("Invalid heightmap format ", im.get_format()))
 	
 	elif ext == "exr":
-		var src_image := Image.load_from_file(fpath)
+		var src_image := Image.load_from_file(ProjectSettings.globalize_path(fpath))
 		# TODO No way to access the error code?
 		if src_image == null:
 			return false
@@ -1696,7 +1696,7 @@ func _import_map(map_type: int, path: String) -> bool:
 	# Heightmap requires special treatment
 	assert(map_type != CHANNEL_HEIGHT)
 
-	var im := Image.load_from_file(path)
+	var im := Image.load_from_file(ProjectSettings.globalize_path(path))
 	# TODO No way to get the error code?
 	if im == null:
 		return false

--- a/addons/zylann.hterrain/tools/brush/brush.gd
+++ b/addons/zylann.hterrain/tools/brush/brush.gd
@@ -147,7 +147,7 @@ func is_shape_cycling_enabled() -> bool:
 
 static func load_shape_from_image_file(fpath: String, logger, retries := 1) -> Texture2D:
 	var im := Image.new()
-	var err := im.load(fpath)
+	var err := im.load(ProjectSettings.globalize_path(fpath))
 	if err != OK:
 		if retries > 0:
 			# TODO There is a bug with Godot randomly being unable to load images.

--- a/addons/zylann.hterrain/tools/importer/importer_dialog.gd
+++ b/addons/zylann.hterrain/tools/importer/importer_dialog.gd
@@ -294,7 +294,7 @@ static func _load_image_size(path: String, logger, bit_depth: int) -> HT_ImageSi
 	if ext == "png" or ext == "exr":
 		# Godot can load these formats natively
 		var im := Image.new()
-		var err := im.load(path)
+		var err := im.load(ProjectSettings.globalize_path(path))
 		if err != OK:
 			logger.error("An error occurred loading image '{0}', code {1}".format([path, err]))
 			result.error_code = err

--- a/addons/zylann.hterrain/tools/packed_textures/packed_texture_util.gd
+++ b/addons/zylann.hterrain/tools/packed_textures/packed_texture_util.gd
@@ -39,7 +39,7 @@ static func generate_image(sources: Dictionary, resolution: int, logger) -> HT_R
 		else:
 			# File
 			src_image = Image.new()
-			var err := src_image.load(src_path)
+			var err := src_image.load(ProjectSettings.globalize_path(src_path))
 			if err != OK:
 				return HT_Result.new(false, "Could not open file \"{0}\": {1}" \
 					.format([src_path, HT_Errors.get_message(err)])) \

--- a/addons/zylann.hterrain/tools/preview_generator.gd
+++ b/addons/zylann.hterrain/tools/preview_generator.gd
@@ -24,7 +24,7 @@ func _generate_from_path(path: String, size: Vector2i, metadata: Dictionary) -> 
 	var normals_fname := str(HTerrainData.get_channel_name(HTerrainData.CHANNEL_NORMAL), ".png")
 	var normals_path := data_dir.path_join(normals_fname)
 	var normals := Image.new()
-	var err := normals.load(normals_path)
+	var err := normals.load(ProjectSettings.globalize_path(normals_path))
 	if err != OK:
 		_logger.error("Could not load '{0}', error {1}" \
 			.format([normals_path, HT_Errors.get_message(err)]))

--- a/addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd
+++ b/addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd
@@ -379,7 +379,7 @@ func _set_ui_slot_texture_from_path(im_path: String, type: int):
 	else:
 		# Regular path
 		im = Image.new()
-		var err := im.load(im_path)
+		var err := im.load(ProjectSettings.globalize_path(im_path))
 		if err != OK:
 			_logger.error(str("Unable to load image from ", im_path))
 			# TODO Different icon for images that can't load?

--- a/addons/zylann.hterrain/tools/util/editor_util.gd
+++ b/addons/zylann.hterrain/tools/util/editor_util.gd
@@ -95,7 +95,7 @@ static func load_texture(path: String, logger) -> Texture:
 	# See https://github.com/godotengine/godot/issues/17483
 	logger.error(str("Failed to load texture ", path, ", attempting to load manually"))
 	var im := Image.new()
-	var err = im.load(path)
+	var err = im.load(ProjectSettings.globalize_path(path))
 	if err != OK:
 		logger.error(str("Failed to load image ", path))
 		return null


### PR DESCRIPTION
Fixes #432

Adding `ProjectSettings.globalize_path()` to image.load and image.load_as_file calls to remove annoying warning messages when saving and opening maps.