### PR TITLE
Update smart-pick alternatives to work with ambientcg and polyhaven

### DIFF
--- a/addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd
+++ b/addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd
@@ -27,7 +27,7 @@ const _compress_names = ["Raw", "Lossless", "Lossy", "VRAM"]
 const _smart_pick_file_keywords = [
 	["albedo", "color", "col", "diffuse"],
 	["bump", "height", "depth", "displacement", "disp"],
-	["normal", "norm", "nrm"],
+	["normal", "norm", "nrm", "normalgl"],
 	["roughness", "rough", "rgh"]
 ]
 

--- a/addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd
+++ b/addons/zylann.hterrain/tools/texture_editor/set_editor/texture_set_import_editor.gd
@@ -25,9 +25,9 @@ const _compress_names = ["Raw", "Lossless", "Lossy", "VRAM"]
 
 # Indexed by HTerrainTextureSet.SRC_TYPE_* constants
 const _smart_pick_file_keywords = [
-	["albedo", "color", "col", "diffuse"],
+	["albedo", "color", "col", "diffuse", "diff"],
 	["bump", "height", "depth", "displacement", "disp"],
-	["normal", "norm", "nrm", "normalgl"],
+	["normal", "norm", "nrm", "normalgl", "nor_gl"],
 	["roughness", "rough", "rgh"]
 ]
 


### PR DESCRIPTION
Updated the smart pick alternatives in the import_textures dialog to auto-pick textures with the naming used by ambientcg and polyhaven downloaded textures.

Now you can just load the color/diffuse textures and the plugin should auto-load the other textures.
Previously, ambientcg was not auto-loading the normal texture (named normalGL)
And polyhaven was not picking anything.