### PR TITLE
Usability & Quality of life: Add shortcut widget to change brush size and opacity

### DIFF
--- a/addons/zylann.hterrain/tools/brush/brush.gd
+++ b/addons/zylann.hterrain/tools/brush/brush.gd
@@ -10,12 +10,17 @@ const HT_Painter = preload("./painter.gd")
 
 const SHAPES_DIR = "addons/zylann.hterrain/tools/brush/shapes"
 const DEFAULT_BRUSH_TEXTURE_PATH = SHAPES_DIR + "/round2.exr"
+
 # Reasonable size for sliders to be usable
+const MIN_SIZE_FOR_SLIDERS = 2
 const MAX_SIZE_FOR_SLIDERS = 500
+const MIN_OPACITY_FOR_SLIDERS = 0
+const MAX_OPACITY_FOR_SLIDERS = 100
 # Absolute size limit. Terrains can't be larger than that, and it will be very slow to paint
 const MAX_SIZE = 4000
 
 signal size_changed(new_size)
+signal opacity_changed(new_opacity)
 signal shapes_changed
 signal shape_index_changed
 
@@ -50,7 +55,11 @@ func get_size() -> int:
 
 
 func set_opacity(opacity: float):
-	_opacity = clampf(opacity, 0.0, 1.0)
+	var new_opacity := clampf(opacity, 0.0, 1.0)
+
+	if new_opacity != _opacity:
+		_opacity = new_opacity
+		opacity_changed.emit(_opacity)
 
 
 func get_opacity() -> float:
@@ -213,5 +222,3 @@ func configure_paint_input(painters: Array[HT_Painter], position: Vector2, press
 func on_paint_end():
 	_prev_position = Vector2(-999, -999)
 	_prev_time_ms = 0
-
-

--- a/addons/zylann.hterrain/tools/brush/brush_editor.gd
+++ b/addons/zylann.hterrain/tools/brush/brush_editor.gd
@@ -68,6 +68,9 @@ func _ready():
 	_slope_limit_control.changed.connect(_on_slope_limit_changed)
 	
 	_size_slider.max_value = HT_Brush.MAX_SIZE_FOR_SLIDERS
+	_size_slider.min_value = HT_Brush.MIN_SIZE_FOR_SLIDERS
+	_opacity_slider.max_value = HT_Brush.MAX_OPACITY_FOR_SLIDERS
+	_opacity_slider.min_value = HT_Brush.MIN_OPACITY_FOR_SLIDERS
 	#if NativeFactory.is_native_available():
 	#	_size_slider.max_value = 200
 	#else:
@@ -104,6 +107,8 @@ func set_terrain_painter(terrain_painter: HT_TerrainPainter):
 		_terrain_painter.flatten_height_changed.disconnect(_on_flatten_height_changed)
 		_terrain_painter.get_brush().shapes_changed.disconnect(_on_brush_shapes_changed)
 		_terrain_painter.get_brush().shape_index_changed.disconnect(_on_brush_shape_index_changed)
+		_terrain_painter.get_brush().size_changed.disconnect(_on_brush_size_changed)
+		_terrain_painter.get_brush().opacity_changed.disconnect(_on_brush_opacity_changed)
 	
 	_terrain_painter = terrain_painter
 
@@ -138,6 +143,8 @@ func set_terrain_painter(terrain_painter: HT_TerrainPainter):
 		_terrain_painter.flatten_height_changed.connect(_on_flatten_height_changed)
 		brush.shapes_changed.connect(_on_brush_shapes_changed)
 		brush.shape_index_changed.connect(_on_brush_shape_index_changed)
+		brush.size_changed.connect(_on_brush_size_changed)
+		brush.opacity_changed.connect(_on_brush_opacity_changed)
 
 
 func _on_flatten_height_changed():
@@ -149,6 +156,14 @@ func _on_brush_shapes_changed():
 	_update_shape_preview()
 
 
+func _on_brush_size_changed(new_size):
+	_update_brush_size(new_size)
+
+
+func _on_brush_opacity_changed(new_opacity):
+	_update_brush_opacity(new_opacity)
+
+
 func _on_brush_shape_index_changed():
 	_update_shape_preview()
 
@@ -157,6 +172,16 @@ func _update_shape_preview():
 	var brush := _terrain_painter.get_brush()
 	var i := brush.get_shape_index()
 	_shape_texture_rect.texture = brush.get_shape(i)
+
+
+func _update_brush_size(new_size):
+	if _terrain_painter != null:
+		_size_slider.set_value_no_signal(new_size)
+
+
+func _update_brush_opacity(new_opacity):
+	if _terrain_painter != null:
+		_opacity_slider.set_value_no_signal(new_opacity * _opacity_slider.max_value)
 
 
 func set_display_mode(mode: int):

--- a/addons/zylann.hterrain/tools/brush/brush_editor_overlay.gd
+++ b/addons/zylann.hterrain/tools/brush/brush_editor_overlay.gd
@@ -1,0 +1,99 @@
+@tool
+extends Control
+
+const MIN_UI_CIRCLE_SIZE = 40
+const MAX_UI_CIRCLE_SIZE = 500
+
+@onready var _brush_size_background: TextureRect = %BrushSizeBackground
+@onready var _brush_size_preview: TextureRect = %BrushSizePreview
+@onready var _value_label: Label = %ValueLabel
+@onready var _overlay_name_label: Label = %OverlayNameLabel
+@onready var _exponential_slider: HSlider = %ExponentialSlider
+
+@export var brush_size_factor: float = 2.5
+@export var min_value: float = -1
+@export var max_value: float = -1
+var _brush_preview_color: Color = Color.LIGHT_GREEN
+var _dpi_scale: float = 1.0
+var _value: float = 0.0
+
+signal on_value_selected(new_value: int)
+signal on_cancel
+
+var background_margin: int = 10
+
+
+func _physics_process(delta: float) -> void:
+	_update_size(_get_mouse_distance())
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+			on_value_selected.emit(_value)
+		else:
+			on_cancel.emit()
+	if event is InputEventKey:
+		if event.keycode == KEY_ESCAPE and event.pressed:
+			on_cancel.emit()
+
+
+func set_brush_preview_color(brush_color: Color) -> void:
+	_brush_preview_color = brush_color
+	_update_brush_preview_color()
+
+
+func _update_brush_preview_color() -> void:
+	_brush_size_preview.modulate = _brush_preview_color
+
+
+func set_overlay_name(overlay_label_name: String) -> void:
+	_overlay_name_label.text = overlay_label_name
+
+
+func _update_size(value: float) -> void:
+	var dist := clampi(value * brush_size_factor, MIN_UI_CIRCLE_SIZE*_dpi_scale, MAX_UI_CIRCLE_SIZE*_dpi_scale )
+	var ui_size := clampi(dist, MIN_UI_CIRCLE_SIZE*_dpi_scale, MAX_UI_CIRCLE_SIZE*_dpi_scale)
+	_brush_size_background.size = Vector2(ui_size + background_margin, ui_size + background_margin)
+	_brush_size_background.position = Vector2(-( (ui_size/2) + (background_margin/2)) , -( (ui_size/2) + (background_margin/2)))
+	_brush_size_preview.size = Vector2(ui_size, ui_size)
+	_brush_size_preview.position = Vector2(-(ui_size/2) , -(ui_size/2))
+
+	_exponential_slider.min_value = MIN_UI_CIRCLE_SIZE*_dpi_scale
+	_exponential_slider.max_value = MAX_UI_CIRCLE_SIZE*_dpi_scale
+	_exponential_slider.value = (_exponential_slider.min_value+_exponential_slider.max_value)-ui_size
+
+	var re_value: float = absf(1.0-_exponential_slider.get_as_ratio()) * (max_value-min_value)
+	re_value += min_value
+
+	_value = roundi(re_value)
+	_value_label.text = str(_value)
+
+
+func apply_dpi_scale(dpi_scale: float) -> void:
+	_dpi_scale = dpi_scale
+
+
+func setup_start_position(start_pos: Vector2, initial_value: float) -> void:
+	position = start_pos
+
+	_exponential_slider.min_value = MIN_UI_CIRCLE_SIZE*_dpi_scale
+	_exponential_slider.max_value = MAX_UI_CIRCLE_SIZE*_dpi_scale
+
+	var reverse: float = (initial_value - min_value) / (max_value-min_value)
+	reverse = absf(1-reverse)
+	_exponential_slider.set_as_ratio(reverse)
+
+	var ui_size: float = (_exponential_slider.min_value+_exponential_slider.max_value) - _exponential_slider.value
+
+	position.x -= (ui_size/brush_size_factor)
+
+
+func _get_mouse_distance() -> float:
+	var global_mouse_pos: Vector2 = get_global_mouse_position()
+	
+	var distance: float = position.distance_to(global_mouse_pos)
+	if position.x > global_mouse_pos.x:
+		distance = 0
+
+	return distance;

--- a/addons/zylann.hterrain/tools/brush/brush_editor_overlay.tscn
+++ b/addons/zylann.hterrain/tools/brush/brush_editor_overlay.tscn
@@ -1,0 +1,91 @@
+[gd_scene load_steps=5 format=3 uid="uid://d324kwgdf7e6l"]
+
+[ext_resource type="Script" path="res://addons/zylann.hterrain/tools/brush/brush_editor_overlay.gd" id="1_grgos"]
+[ext_resource type="Texture2D" uid="uid://fk2rcx7lsbam" path="res://addons/zylann.hterrain/tools/icons/brush_circle_background.svg" id="2_jeqe2"]
+[ext_resource type="Texture2D" uid="uid://c4ma6f4217y48" path="res://addons/zylann.hterrain/tools/icons/brush_circle.svg" id="3_sw64o"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_0d2ij"]
+font_size = 32
+
+[node name="BrushEditorOverlay" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_grgos")
+min_value = 2.0
+max_value = 500.0
+
+[node name="BrushSizeBackground" type="TextureRect" parent="."]
+unique_name_in_owner = true
+modulate = Color(0.478431, 0.478431, 0.478431, 0.423529)
+layout_mode = 0
+offset_left = -209.0
+offset_top = -209.0
+offset_right = 210.0
+offset_bottom = 210.0
+texture = ExtResource("2_jeqe2")
+expand_mode = 1
+metadata/_edit_use_anchors_ = true
+
+[node name="BrushSizePreview" type="TextureRect" parent="."]
+unique_name_in_owner = true
+modulate = Color(1, 0, 0, 1)
+layout_mode = 1
+offset_left = -204.0
+offset_top = -204.0
+offset_right = 205.0
+offset_bottom = 205.0
+texture = ExtResource("3_sw64o")
+expand_mode = 1
+metadata/_edit_use_anchors_ = true
+
+[node name="ValueLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = -1
+anchor_top = 0.001
+anchor_bottom = 0.001
+offset_left = -35.0
+offset_top = -22.648
+offset_right = 38.0
+offset_bottom = 22.352
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(0.7, 0.7)
+pivot_offset = Vector2(33, 22)
+text = "266"
+label_settings = SubResource("LabelSettings_0d2ij")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="OverlayNameLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = -1
+offset_left = -211.0
+offset_top = -62.0
+offset_right = 400.0
+offset_bottom = 19.0
+scale = Vector2(0.7, 0.7)
+text = "Brush size"
+label_settings = SubResource("LabelSettings_0d2ij")
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ExponentialSlider" type="HSlider" parent="."]
+unique_name_in_owner = true
+visible = false
+layout_mode = 0
+offset_left = -132.0
+offset_top = 50.0
+offset_right = 140.0
+offset_bottom = 66.0
+focus_mode = 0
+mouse_filter = 2
+min_value = 40.0
+max_value = 500.0
+value = 131.0
+exp_edit = true

--- a/addons/zylann.hterrain/tools/brush/settings_dialog/brush_settings_dialog.gd
+++ b/addons/zylann.hterrain/tools/brush/settings_dialog/brush_settings_dialog.gd
@@ -39,6 +39,9 @@ func _ready():
 		return
 	
 	_size_slider.set_max_value(HT_Brush.MAX_SIZE_FOR_SLIDERS)
+	_size_slider.set_min_value(HT_Brush.MIN_SIZE_FOR_SLIDERS)
+	_opacity_slider.set_max_value(HT_Brush.MAX_OPACITY_FOR_SLIDERS)
+	_opacity_slider.set_min_value(HT_Brush.MIN_OPACITY_FOR_SLIDERS)
 	_size_slider.set_greater_max_value(HT_Brush.MAX_SIZE)
 	
 	# TESTING
@@ -277,4 +280,3 @@ func _update_shape_list_buttons():
 
 func _on_shape_list_empty_clicked(at_position, mouse_button_index):
 	_update_shape_list_buttons()
-

--- a/addons/zylann.hterrain/tools/icons/brush_circle.svg
+++ b/addons/zylann.hterrain/tools/icons/brush_circle.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="256"
+   height="256"
+   viewBox="0 0 67.733333 67.733334"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="brush_circle.svg"
+   inkscape:export-filename="focus-camera-icon.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="true"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     inkscape:zoom="1.0406414"
+     inkscape:cx="26.906484"
+     inkscape:cy="224.86133"
+     inkscape:current-layer="layer1"
+     showborder="true" /><defs
+     id="defs1" /><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"><circle
+       style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:2.64583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="path2"
+       cx="33.734375"
+       cy="33.734375"
+       r="31.088543" /></g></svg>

--- a/addons/zylann.hterrain/tools/icons/brush_circle_background.svg
+++ b/addons/zylann.hterrain/tools/icons/brush_circle_background.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="256"
+   height="256"
+   viewBox="0 0 67.733333 67.733334"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="brush_circle_background.svg"
+   inkscape:export-filename="focus-camera-icon.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="true"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     inkscape:zoom="2.0812827"
+     inkscape:cx="119.15729"
+     inkscape:cy="187.38444"
+     inkscape:current-layer="layer1"
+     showborder="true" /><defs
+     id="defs1" /><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"><circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.64583;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
+       id="path2"
+       cx="33.734375"
+       cy="33.734375"
+       r="31.088543" /></g></svg>


### PR DESCRIPTION
A much needed quality of life feature.
This adds a simple widget to quickly change the size and opacity of the brush.
Press the hotkey and move the mouse the set the value.

https://github.com/user-attachments/assets/7245457d-c415-4999-a68e-d187bccac7e3

Right now, the hotkeys are set to:
- **G for size**
- **H for opacity**

We can add an option to change the hotkeys later.

This PR also fixes a bug where changing the size/opacity in the brush settings dialogue would not change the bottom panel sliders

https://github.com/user-attachments/assets/c83282ba-a959-4d5b-a03d-4f72a1e6d6b1

----
Based on TerraBrush's UI features