### PR TITLE
Fix detail layer visibility

### DIFF
--- a/addons/zylann.hterrain/hterrain_detail_layer.gd
+++ b/addons/zylann.hterrain/hterrain_detail_layer.gd
@@ -425,7 +425,7 @@ func _notification(what: int):
 			_set_world(null)
 
 		NOTIFICATION_VISIBILITY_CHANGED:
-			_set_visible(visible)
+			_set_visible(is_visible_in_tree())
 			
 		NOTIFICATION_PREDELETE:
 			# Force DirectMeshInstances to be destroyed before the material.


### PR DESCRIPTION
This is a simple fix to address detail layers remaining visible when an ancestor node is invisible.

The issue was caused by [this line][broken_line] in `hterrain_detail_layer.gd`, where `visible` is passed to `_set_visible`. Since `visible` refers to the visibility of the detail layer node specifically, this causes the detail layer to remain visible even if its ancestor nodes are invisible. The fix is to use `is_visible_in_tree()` instead, which accounts the visibility of ancestor nodes.

[broken_line]: https://github.com/qeaml/godot_heightmap_plugin/blob/85b85e08526f2872a7b20e03e0b7e18bc825e83c/addons/zylann.hterrain/hterrain_detail_layer.gd#L428