### PR TITLE
Minimized texture editor bug fix with explicit anchors

### DIFF
--- a/addons/zylann.hterrain/tools/texture_editor/texture_editor.tscn
+++ b/addons/zylann.hterrain/tools/texture_editor/texture_editor.tscn
@@ -14,6 +14,9 @@ __meta__ = {
 }
 
 [node name="TextureList" parent="." instance=ExtResource( 2 )]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
 offset_bottom = -26.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]


### PR DESCRIPTION
This pr should fix the minimized texture list bug that I've reported here:

https://github.com/Zylann/godot_heightmap_plugin/issues/488#issuecomment-3523284663

I've closed the issue because it got solved after switching from 1.7.3 dev to 1.7.2, but that was just temporary, the issue can be reproduced in both 1.7.2 and 1.7.3 dev, by letting the editor update automatically to 4.5.1 or forcing a file update using "project > tools > upgrade project files". 

The upgrade changes the scenefiles settings to:
```
layout_mode = 0
anchors_preset = 0
anchor_right = 0.0
anchor_bottom = 0.0
```
from the defaults, which causes the list to be minimized.

Setting the anchors explicitly should fix the issue for good.

