### PR TITLE
Update hterrain_collider to support double-precision builds of Godot

### DIFF
--- a/addons/zylann.hterrain/doc/docs/index.md
+++ b/addons/zylann.hterrain/doc/docs/index.md
@@ -1094,6 +1094,11 @@ This issue happened a few times and had various causes so if the checks mentione
 - If your problem relates to collisions in editor, update the collider using `Terrain -> Update Editor Collider`, because this one does not update automatically yet
 - Godot seems to randomly forget where the terrain saver is, but I need help to find out why because I could never reproduce it. See [issue #120](https://github.com/Zylann/godot_heightmap_plugin/issues/120)
 
+### Collider fails to build properly on double-precision builds
+
+This can happen on [double-precision builds](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html) of Godot. An error message `ERROR: Expected PackedFloat64Array or float Image.` will appear in the debugger.
+
+- Edit `hterrain_collider.gd` to replace `PackedFloat32Array` instead of `PackedFloat64Array`
 
 ### Temporary files
 

--- a/addons/zylann.hterrain/doc/docs/index.md
+++ b/addons/zylann.hterrain/doc/docs/index.md
@@ -1097,8 +1097,24 @@ This issue happened a few times and had various causes so if the checks mentione
 ### Collider fails to build properly on double-precision builds
 
 This can happen on [double-precision builds](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html) of Godot. An error message `ERROR: Expected PackedFloat64Array or float Image.` will appear in the debugger.
+Note that in general, double-precision is not necessary for heightmaps and is considered wasteful; this workaround only exists as a brute-force approach for working within the constraints of the Godot double-precision builds. It is not recommended for generating or editing terrain at runtime.
 
 - Edit `hterrain_collider.gd` to replace `PackedFloat32Array` with `PackedFloat64Array`
+- Convert the call to `terrain_data.get_all_heights()` to `PackedFloat64Array`
+
+For example,
+
+```
+func packed32ToPacked64(p32: PackedFloat32Array) -> PackedFloat64Array:
+	var p64 = PackedFloat64Array();
+	for i in p32.size():
+		p64.append(p32.get(i));
+	return p64;
+
+...
+
+"heights": packed32ToPacked64(terrain_data.get_all_heights()),
+```
 
 ### Temporary files
 

--- a/addons/zylann.hterrain/doc/docs/index.md
+++ b/addons/zylann.hterrain/doc/docs/index.md
@@ -1094,27 +1094,6 @@ This issue happened a few times and had various causes so if the checks mentione
 - If your problem relates to collisions in editor, update the collider using `Terrain -> Update Editor Collider`, because this one does not update automatically yet
 - Godot seems to randomly forget where the terrain saver is, but I need help to find out why because I could never reproduce it. See [issue #120](https://github.com/Zylann/godot_heightmap_plugin/issues/120)
 
-### Collider fails to build properly on double-precision builds
-
-This can happen on [double-precision builds](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html) of Godot. An error message `ERROR: Expected PackedFloat64Array or float Image.` will appear in the debugger.
-Note that in general, double-precision is not necessary for heightmaps and is considered wasteful; this workaround only exists as a brute-force approach for working within the constraints of the Godot double-precision builds. It is not recommended for generating or editing terrain at runtime.
-
-- Edit `hterrain_collider.gd` to replace `PackedFloat32Array` with `PackedFloat64Array`
-- Convert the call to `terrain_data.get_all_heights()` to `PackedFloat64Array`
-
-For example,
-
-```
-func packed32ToPacked64(p32: PackedFloat32Array) -> PackedFloat64Array:
-	var p64 = PackedFloat64Array();
-	for i in p32.size():
-		p64.append(p32.get(i));
-	return p64;
-
-...
-
-"heights": packed32ToPacked64(terrain_data.get_all_heights()),
-```
 
 ### Temporary files
 

--- a/addons/zylann.hterrain/doc/docs/index.md
+++ b/addons/zylann.hterrain/doc/docs/index.md
@@ -1098,7 +1098,7 @@ This issue happened a few times and had various causes so if the checks mentione
 
 This can happen on [double-precision builds](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html) of Godot. An error message `ERROR: Expected PackedFloat64Array or float Image.` will appear in the debugger.
 
-- Edit `hterrain_collider.gd` to replace `PackedFloat32Array` instead of `PackedFloat64Array`
+- Edit `hterrain_collider.gd` to replace `PackedFloat32Array` with `PackedFloat64Array`
 
 ### Temporary files
 

--- a/addons/zylann.hterrain/hterrain_collider.gd
+++ b/addons/zylann.hterrain/hterrain_collider.gd
@@ -110,24 +110,14 @@ func create_from_terrain_data(terrain_data: HTerrainData) -> void:
 	var depth := terrain_data.get_resolution()
 	var height := aabb.size.y
 
-	if():
-		var shape_data = {
-			"width": terrain_data.get_resolution(),
-			"depth": terrain_data.get_resolution(),
-			"heights": terrain_data.get_all_heights(),
-			"min_height": aabb.position.y,
-			"max_height": aabb.end.y
-		}
-		PhysicsServer3D.shape_set_data(_shape_rid, shape_data)
-	else:
-		var shape_data = {
-			"width": terrain_data.get_resolution(),
-			"depth": terrain_data.get_resolution(),
-			"heights": _packed32_to_packed64(terrain_data.get_all_heights()) if _is_double_precision_build() else terrain_data.get_all_heights(),
-			"min_height": aabb.position.y,
-			"max_height": aabb.end.y
-		}
-		PhysicsServer3D.shape_set_data(_shape_rid, shape_data)
+	var shape_data = {
+		"width": terrain_data.get_resolution(),
+		"depth": terrain_data.get_resolution(),
+		"heights": _packed32_to_packed64(terrain_data.get_all_heights()) if _is_double_precision_build() else terrain_data.get_all_heights(),
+		"min_height": aabb.position.y,
+		"max_height": aabb.end.y
+	}
+	PhysicsServer3D.shape_set_data(_shape_rid, shape_data)
 	
 	_update_transform()
 

--- a/addons/zylann.hterrain/hterrain_collider.gd
+++ b/addons/zylann.hterrain/hterrain_collider.gd
@@ -38,7 +38,7 @@ func _init(attached_node: Node, initial_layer: int, initial_mask: int) -> void:
 	PhysicsServer3D.shape_set_data(_shape_rid, {
 		"width": 2,
 		"depth": 2,
-		"heights": PackedFloat64Array([0, 0, 0, 0]) _is_double_precision_build() else PackedFloat32Array([0, 0, 0, 0]),
+		"heights": PackedFloat64Array([0, 0, 0, 0]) if _is_double_precision_build() else PackedFloat32Array([0, 0, 0, 0]),
 		"min_height": -1,
 		"max_height": 1
 	})

--- a/addons/zylann.hterrain/hterrain_collider.gd
+++ b/addons/zylann.hterrain/hterrain_collider.gd
@@ -9,17 +9,6 @@ var _terrain_transform := Transform3D()
 var _terrain_data : HTerrainData = null
 var _logger = HT_Logger.get_for(self)
 
-func _is_double_precision_build() -> bool:
-	return ProjectSettings.get_setting("application/config/features").has("Double Precision")
-
-func _packed32_to_packed64(p32: PackedFloat32Array) -> PackedFloat64Array:
-	# This is a slower brute-force method as a workaround to double-precision builds requiring PackedFloat64Array. Otherwise, colliders would fail to build on double-precision builds entirely.
-	# In an ideal world Godot would be updated to accept a PackedFloat32Array since it uses it under the hood anyways
-	var p64 = PackedFloat64Array();
-	for i in p32.size():
-		p64.append(p32.get(i));
-	return p64;
-
 func _init(attached_node: Node, initial_layer: int, initial_mask: int) -> void:
 	_logger.debug("HTerrainCollider: creating body")
 	assert(attached_node != null)
@@ -47,6 +36,20 @@ func _init(attached_node: Node, initial_layer: int, initial_mask: int) -> void:
 	
 	# This makes collision hits report the provided object as `collider`
 	PhysicsServer3D.body_attach_object_instance_id(_body_rid, attached_node.get_instance_id())
+
+
+static func _is_double_precision_build() -> bool:
+	return ProjectSettings.get_setting("application/config/features").has("Double Precision")
+
+
+static func _packed32_to_packed64(p32: PackedFloat32Array) -> PackedFloat64Array:
+	# This is a slower brute-force method as a workaround to double-precision builds requiring PackedFloat64Array. Otherwise, colliders would fail to build on double-precision builds entirely.
+	# In an ideal world Godot would be updated to accept a PackedFloat32Array since it uses it under the hood anyways
+	var p64 = PackedFloat64Array();
+	p64.resize(p32.size())
+	for i in p32.size():
+		p64.set(i, p32[i]);
+	return p64;
 
 
 func set_collision_layer(layer: int) -> void:

--- a/addons/zylann.hterrain/hterrain_collider.gd
+++ b/addons/zylann.hterrain/hterrain_collider.gd
@@ -9,6 +9,16 @@ var _terrain_transform := Transform3D()
 var _terrain_data : HTerrainData = null
 var _logger = HT_Logger.get_for(self)
 
+func _is_double_precision_build() -> bool:
+	return ProjectSettings.get_setting("application/config/features").has("Double Precision")
+
+func _packed32_to_packed64(p32: PackedFloat32Array) -> PackedFloat64Array:
+	# This is a slower brute-force method as a workaround to double-precision builds requiring PackedFloat64Array. Otherwise, colliders would fail to build on double-precision builds entirely.
+	# In an ideal world Godot would be updated to accept a PackedFloat32Array since it uses it under the hood anyways
+	var p64 = PackedFloat64Array();
+	for i in p32.size():
+		p64.append(p32.get(i));
+	return p64;
 
 func _init(attached_node: Node, initial_layer: int, initial_mask: int) -> void:
 	_logger.debug("HTerrainCollider: creating body")
@@ -28,7 +38,7 @@ func _init(attached_node: Node, initial_layer: int, initial_mask: int) -> void:
 	PhysicsServer3D.shape_set_data(_shape_rid, {
 		"width": 2,
 		"depth": 2,
-		"heights": PackedFloat32Array([0, 0, 0, 0]),
+		"heights": PackedFloat64Array([0, 0, 0, 0]) _is_double_precision_build() else PackedFloat32Array([0, 0, 0, 0]),
 		"min_height": -1,
 		"max_height": 1
 	})
@@ -100,15 +110,24 @@ func create_from_terrain_data(terrain_data: HTerrainData) -> void:
 	var depth := terrain_data.get_resolution()
 	var height := aabb.size.y
 
-	var shape_data = {
-		"width": terrain_data.get_resolution(),
-		"depth": terrain_data.get_resolution(),
-		"heights": terrain_data.get_all_heights(),
-		"min_height": aabb.position.y,
-		"max_height": aabb.end.y
-	}
-
-	PhysicsServer3D.shape_set_data(_shape_rid, shape_data)
+	if():
+		var shape_data = {
+			"width": terrain_data.get_resolution(),
+			"depth": terrain_data.get_resolution(),
+			"heights": terrain_data.get_all_heights(),
+			"min_height": aabb.position.y,
+			"max_height": aabb.end.y
+		}
+		PhysicsServer3D.shape_set_data(_shape_rid, shape_data)
+	else:
+		var shape_data = {
+			"width": terrain_data.get_resolution(),
+			"depth": terrain_data.get_resolution(),
+			"heights": _packed32_to_packed64(terrain_data.get_all_heights()) if _is_double_precision_build() else terrain_data.get_all_heights(),
+			"min_height": aabb.position.y,
+			"max_height": aabb.end.y
+		}
+		PhysicsServer3D.shape_set_data(_shape_rid, shape_data)
 	
 	_update_transform()
 


### PR DESCRIPTION
Adds details on how to get collision to work on [Double-Precision builds of Godot](https://docs.godotengine.org/en/stable/tutorials/physics/large_world_coordinates.html).

<img width="514" height="37" alt="image" src="https://github.com/user-attachments/assets/c3ec3831-0d38-4ebb-a603-ac44ed955c60" />
