### PR TITLE
Fix inverted antitile condition

### DIFF
--- a/addons/zylann.hterrain/shaders/simple4_lite.gdshader
+++ b/addons/zylann.hterrain/shaders/simple4_lite.gdshader
@@ -183,9 +183,9 @@ void fragment() {
 
 	} else {
 		if (u_tile_reduction[3] > 0.0) {
-			ab3 = texture(u_ground_albedo_bump_3, ground_uv);
-		} else {
 			ab3 = texture_antitile(u_ground_albedo_bump_3, ground_uv);
+		} else {
+			ab3 = texture(u_ground_albedo_bump_3, ground_uv);
 		}
 	}
 


### PR DESCRIPTION
The antitile texture selection logic was inverted for layer 3.

When `u_tile_reduction[3] > 0.0`, the shader used `texture()` instead of `texture_antitile()`, causing the antitile setting to behave opposite to its intended effect. This change swaps the branches so antitile sampling is used when tile reduction is enabled.
