### PR TITLE
Fix DetailLayer grass chunks not being restored after re-entering the scene tree

### DIFF
--- a/addons/zylann.hterrain/hterrain_detail_layer.gd
+++ b/addons/zylann.hterrain/hterrain_detail_layer.gd
@@ -194,7 +194,7 @@ var _material: ShaderMaterial = null
 var _default_shader: Shader = null
 
 # Vector2i => Chunk
-var _chunks := {}
+var _chunks: Dictionary[Vector2i, HT_DetailChunk] = {}
 
 var _multimesh: MultiMesh
 var _multimesh_need_regen = true
@@ -236,6 +236,7 @@ func _enter_tree() -> void:
 		terrain._internal_add_detail_layer(self)
 
 	_update_material()
+	_force_chunk_updates_next_frame = true
 
 
 func _exit_tree() -> void:
@@ -479,7 +480,6 @@ func process(delta: float, viewer_pos: Vector3) -> void:
 		return
 
 	if _multimesh_need_regen:
-		print("Regen multimesh")
 		_regen_multimesh()
 		_multimesh_need_regen = false
 		# Crash workaround for Godot 3.1

--- a/addons/zylann.hterrain/hterrain_detail_layer.gd
+++ b/addons/zylann.hterrain/hterrain_detail_layer.gd
@@ -193,8 +193,8 @@ class HT_DetailChunk:
 var _material: ShaderMaterial = null
 var _default_shader: Shader = null
 
-# Vector2i => Chunk
-var _chunks: Dictionary[Vector2i, HT_DetailChunk] = {}
+# Dictionary[Vector2i, HT_DetailChunk] (Godot 4.4 compatible syntax)
+var _chunks := {}
 
 var _multimesh: MultiMesh
 var _multimesh_need_regen = true


### PR DESCRIPTION
This is a fix for the issue https://github.com/Zylann/godot_heightmap_plugin/issues/501

When `HTerrainDetailLayer` exits the scene tree, `_exit_tree()` recycles all chunk instances by setting their visibility to `false` and storing them in `_multimesh_instance_pool`, then clears the `_chunks` dictionary.

However, when the node later re-enters the scene tree, `_enter_tree()` only updates the material and does not restore the recycled chunk instances or repopulate `_chunks`. **As a result, detail layer instances (grass, etc.) remain hidden until another action triggers a full chunk update. (i.e. closing and opening the scene again)**

This change sets `_force_chunk_updates_next_frame` when the node enters the scene tree. The existing update path already handles restoring pooled chunk instances, reapplying visibility and material parameters, and rebuilding the `_chunks` dictionary.

This ensures detail layer chunks are correctly recreated after the node is removed from and re-added to the scene tree.